### PR TITLE
Add option to write output to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ nodetree(process.cwd(), {
   directories: false,
   level: 2,
   prune: false,
-  noreport: false
+  noreport: false,
+  tofile: 'path/to/file'
 });
 ```
 
@@ -83,6 +84,11 @@ Type: `Boolean`
 Default: `false`  
 See cli option `--noreport` below.  
 
+#### options.tofile
+Type: `String`  
+Default: `null`  
+See cli option `--tofile` below. 
+
 ## CLI OPTIONS
 
   * `-a`:
@@ -102,6 +108,9 @@ See cli option `--noreport` below.
 
   * `--version`:
     Outputs the version of nodetree.
+    
+  * `--tofile`:
+    Outputs the results to the file specified instead of the console. The file is created if it doesn't exist.
 
 ## AUTHOR
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ function Nodetree(basepath, opts) {
   var fileCount = 0;
   var isWalking = 0;
   var options = _.extend(defaults, opts);
-  var resultsTree = [];
   var startpath = '';
 
   normalizeStartpath(basepath);
@@ -77,7 +76,7 @@ function Nodetree(basepath, opts) {
       // Replace a pipe with an indent if the parent does not have a next sibling.
       depth[depth.length-2] = chevron.indent;
     }
-    resultsTree.push(depth.join('') + file + '\n');
+    console.log(depth.join('') + file);
   }
 
 
@@ -104,13 +103,14 @@ function Nodetree(basepath, opts) {
    * @method  printResults
    */
   function printResults() {
+    var results = [];
     if (!options.noreport) {
-      resultsTree.push('\n' + dirCount + ' directories');
+      results.push('\n' + dirCount + ' directories');
       if (!options.directories) {
-        resultsTree.push(', ' + fileCount + ' files');
+        results.push(', ' + fileCount + ' files');
       }
     }
-    console.log(resultsTree.join(''));
+    console.log(results.join(''));
   }
 
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ var defaults = {
   directories: false,
   level: null,
   prune: false,
-  noreport: false
+  noreport: false,
+  tofile: ''
 };
 var dotRegex = /^\.$/;
 var hiddenRegex = /^\./;
@@ -36,6 +37,7 @@ function Nodetree(basepath, opts) {
   var isWalking = 0;
   var options = _.extend(defaults, opts);
   var startpath = '';
+  var results = '';
 
   normalizeStartpath(basepath);
 
@@ -43,7 +45,7 @@ function Nodetree(basepath, opts) {
   // Start tree walking
   // ---------------------------------------------------------------------------
   if (fs.existsSync(startpath) && fs.statSync(startpath).isDirectory()) {
-    console.log(basepath);
+    results += basepath + '\n';
     walk(startpath, []);
   } else {
     console.log(basepath, '[error opening dir]');
@@ -76,7 +78,7 @@ function Nodetree(basepath, opts) {
       // Replace a pipe with an indent if the parent does not have a next sibling.
       depth[depth.length-2] = chevron.indent;
     }
-    console.log(depth.join('') + file);
+    results += depth.join('') + file + '\n';
   }
 
 
@@ -200,6 +202,14 @@ function Nodetree(basepath, opts) {
       });
     }
     checkIfComplete();
+  }
+
+  if (options.tofile) {
+    return fs.writeFile(options.tofile, results, function (err) {
+      if (err) throw err;
+    });
+  } else {
+    return console.log(results);
   }
 }
 

--- a/man/man.1/nodetree.1.html
+++ b/man/man.1/nodetree.1.html
@@ -74,7 +74,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>nodetree</code>  [<code>-ad</code>]  [<code>-L</code>  <var>level</var>] [<code>--noreport</code>] [<code>--version</code>] [<code>--help</code>] [<code>--prune</code>] [<var>directory</var> ...]</p>
+<p><code>nodetree</code>  [<code>-ad</code>]  [<code>-L</code>  <var>level</var>] [<code>--noreport</code>] [<code>--version</code>] [<code>--help</code>] [<code>--prune</code>] [<code>--tofile</code>] [<var>directory</var> ...] </p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -91,6 +91,7 @@
 <dt class="flush"><code>--prune</code></dt><dd><p>Makes tree prune empty directories from the output.</p></dd>
 <dt><code>--noreport</code></dt><dd><p>Omits printing of the file and directory report at the end of the tree listing.</p></dd>
 <dt><code>--version</code></dt><dd><p>Outputs the version of nodetree.</p></dd>
+<dt><code>--tofile</code></dt><dd><p>Outputs the results to the file specified.</p></dd>
 </dl>
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodetree",
   "private": false,
   "preferGlobal": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Larry Gordon",
     "email": "lgordon@psyrendust.com",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
   "bin": {
     "nodetree": "cli.js"
   },
+  "main": "index.js",
   "directories": {
     "man": "man/man.1"
   },
   "scripts": {},
-  "files": [
-    "index.js",
-    "cli.js"
-  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/psyrendust/nodetree.git"


### PR DESCRIPTION
Adding an option to enable output to  be written to a file whose path is specified in the option as `{tofile: 'path/to/file'}`. Writing to the console is still the default behavior unless this option is added.
